### PR TITLE
Adding Column visibility

### DIFF
--- a/lib/slick_column.dart
+++ b/lib/slick_column.dart
@@ -61,6 +61,8 @@ class Column {
   String get headerCssClass => _src['headerCssClass'];
   String get cssClass => _src['cssClass'];
   int get previousWidth => _src['previousWidth'];
+  //visible
+  bool get visible => _src['visible'];
 
   String get toolTip => _src['toolTip'];
   //unique id for differeicent from same field name
@@ -149,6 +151,9 @@ class Column {
   void set header(Map _) {
     _src['header'] = _;
   }
+  void set visible(bool item) {
+    _src['visible'] = item;
+  }
 
   factory Column.fromMap(Map<String, dynamic> src) {
     Column c = new Column();
@@ -190,7 +195,8 @@ class Column {
     'defaultSortAsc': true,
     'focusable': true,
     'selectable': true,
-    'cannotTriggerInsert': false
+    'cannotTriggerInsert': false,
+    'visible': true
   };
   String toString() {
     return _src.toString();

--- a/lib/slick_grid.dart
+++ b/lib/slick_grid.dart
@@ -65,6 +65,7 @@ class SlickGrid {
   //each item will render as row
   List data;
   List<Column> columns;
+  List<Column> allColumns;
   Map options={};
  // StreamSubscription<Event> _ancestorScrollSubscribe;
   List _subscriptionList=[];
@@ -114,8 +115,8 @@ class SlickGrid {
    * @param data List of object
    * @param columns column definition
    */
-  SlickGrid(this.container, this.data, this.columns, Map options){
-    
+  SlickGrid(this.container, this.data, this.allColumns, Map options){
+    this.columns = new List<Column>.from(this.allColumns.where((c) => c.visible));
     defaults = {
              //   '_renderLatency': 150,   //mobile device should put larger lantency
 //                '_scrollerDistToRender':200,
@@ -1780,7 +1781,9 @@ class SlickGrid {
 
     
     setColumns(List<Column> columnDefinitions) {
-      columns = columnDefinitions;
+      allColumns = columnDefinitions;
+      columns = new List<Column>.from(columnDefinitions.where((c) => c.visible));
+      //columns = columnDefinitions;
 
       this.columnsById = {};
       for (var i = 0; i < columns.length; i++) {


### PR DESCRIPTION
This is a quick way to add Column visibility.  I single out all
“visible” columns for grid consumption. This should have a very small
impact. I tried resetting slick_grid.dart > columns in two places.
Please let me know  if this is not advisable. I tested most of the examples and they all seem okay. I'm able to sort, drag, etc. columns.

The main goal here is to allow hidden/visible columns be fed into the grid. If the user needs to hide/show a column, they just need to change their local list and feed it to setColumns. I'm open to any suggestions if this approach is not okay. 

Thank you.